### PR TITLE
Add weights loading to benchmark

### DIFF
--- a/src/scripts/agent_loader.py
+++ b/src/scripts/agent_loader.py
@@ -46,18 +46,23 @@ def available_agents():
     return _AGENT_MAP
 
 
-def _construct(cls, seed=None):
-    # Construct agent, passing seed if supported
+def _construct(cls, seed=None, weights_path=None):
+    # Construct agent, passing supported kwargs
     try:
         sig = inspect.signature(cls)
+        kwargs = {}
+
         if "seed" in sig.parameters:
-            return cls(seed=seed)
-        return cls()
+            kwargs["seed"] = seed
+        if "weights_path" in sig.parameters:
+            kwargs["weights_path"] = weights_path
+
+        return cls(**kwargs)
     except (TypeError, ValueError):
         return cls()
 
 
-def load_agent(name_or_spec, seed=None):
+def load_agent(name_or_spec, seed=None, weights_path=None):
     # Load agent by short name or module:Class spec
     s = name_or_spec.strip()
 
@@ -67,11 +72,11 @@ def load_agent(name_or_spec, seed=None):
         cls = getattr(mod, class_name)
         if not inspect.isclass(cls) or not issubclass(cls, Agent):
             raise ValueError(f"{s!r} is not an Agent subclass")
-        return _construct(cls, seed=seed)
+        return _construct(cls, seed=seed, weights_path=weights_path)
 
     key = s.lower()
     amap = available_agents()
     if key not in amap:
         opts = ", ".join(sorted(amap.keys()))
         raise ValueError(f"Unknown agent name: {s!r}. Available: {opts}")
-    return _construct(amap[key], seed=seed)
+    return _construct(amap[key], seed=seed, weights_path=weights_path)

--- a/src/scripts/benchmark.py
+++ b/src/scripts/benchmark.py
@@ -33,7 +33,16 @@ def _pct(x, total):
     return f"{(100.0 * x / total):.1f}%"
 
 
-def run_benchmark(black, white, games, seed=None, swap_sides=False, csv_path=None):
+def run_benchmark(
+    black,
+    white,
+    games,
+    seed=None,
+    swap_sides=False,
+    csv_path=None,
+    black_weights=None,
+    white_weights=None,
+):
     # Run N matches and collect stats
     stats = Stats()
     rows = []
@@ -41,12 +50,21 @@ def run_benchmark(black, white, games, seed=None, swap_sides=False, csv_path=Non
     for i in range(games):
         if swap_sides and (i % 2 == 1):
             b_name, w_name = white, black
+            b_weights, w_weights = white_weights, black_weights
         else:
             b_name, w_name = black, white
+            b_weights, w_weights = black_weights, white_weights
 
         game_seed = None if seed is None else seed + i * 1000
 
-        winner = play_match(b_name, w_name, seed=game_seed, print_board=False)
+        winner = play_match(
+            b_name,
+            w_name,
+            seed=game_seed,
+            print_board=False,
+            black_weights=b_weights,
+            white_weights=w_weights,
+        )
         stats.record(winner)
 
         if csv_path is not None:
@@ -77,6 +95,8 @@ def main():
 
     parser.add_argument("--black", default=None)
     parser.add_argument("--white", default=None)
+    parser.add_argument("--black-weights", default=None)
+    parser.add_argument("--white-weights", default=None)
     parser.add_argument("--games", type=int, default=100)
     parser.add_argument("--seed", type=int, default=None)
     parser.add_argument("--swap-sides", action="store_true")
@@ -100,6 +120,8 @@ def main():
             seed=args.seed,
             swap_sides=args.swap_sides,
             csv_path=csv_path,
+            black_weights=args.black_weights,
+            white_weights=args.white_weights,
         )
     except Exception as e:
         print(f"Benchmark failed: {e}", file=sys.stderr)

--- a/src/scripts/run_match.py
+++ b/src/scripts/run_match.py
@@ -7,11 +7,23 @@ from gomoku import rules
 from scripts.agent_loader import load_agent
 
 
-def play_match(black_name, white_name, seed=None, print_board=False, max_illegal_retries=3):
+def play_match(
+    black_name,
+    white_name,
+    seed=None,
+    print_board=False,
+    max_illegal_retries=3,
+    black_weights=None,
+    white_weights=None,
+):
     # Run a single match and return winner or None for draw
 
-    black_agent = load_agent(black_name, seed=seed)
-    white_agent = load_agent(white_name, seed=None if seed is None else seed + 1)
+    black_agent = load_agent(black_name, seed=seed, weights_path=black_weights)
+    white_agent = load_agent(
+        white_name,
+        seed=None if seed is None else seed + 1,
+        weights_path=white_weights,
+    )
 
     game = Game(board=Board(), black_agent=black_agent, white_agent=white_agent, to_move=BLACK)
 
@@ -48,12 +60,21 @@ def main():
     parser = argparse.ArgumentParser(description="Run a single Gomoku match (CLI).")
     parser.add_argument("--black", default="random")
     parser.add_argument("--white", default="greedy")
+    parser.add_argument("--black-weights", default=None)
+    parser.add_argument("--white-weights", default=None)
     parser.add_argument("--seed", type=int, default=None)
     parser.add_argument("--print-board", action="store_true")
     args = parser.parse_args()
 
     try:
-        w = play_match(args.black, args.white, seed=args.seed, print_board=args.print_board)
+        w = play_match(
+            args.black,
+            args.white,
+            seed=args.seed,
+            print_board=args.print_board,
+            black_weights=args.black_weights,
+            white_weights=args.white_weights,
+        )
     except ValueError as e:
         print(str(e), file=sys.stderr)
         return 2


### PR DESCRIPTION
## Summary
What does this PR change?

## Testing
- [ ] pytest

## Notes
Anything reviewers should know.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI plumbing and agent construction kwargs, with minimal impact beyond enabling optional `weights_path` injection into agents that support it.
> 
> **Overview**
> Adds optional per-side weights support when running games from scripts.
> 
> `run_match.py` and `benchmark.py` accept `--black-weights`/`--white-weights` flags and propagate them through `play_match()` and `run_benchmark()`, including correct swapping when `--swap-sides` is used. `agent_loader.load_agent()`/`_construct()` now detect and pass a `weights_path` constructor kwarg (alongside `seed`) when the selected agent class supports it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a0d430a98b6d7b1b35cf63c00f6c95e73903243. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->